### PR TITLE
make the lite in netprobe_lite mean something ;)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:latest
+# Dockerfile for netprobe_lite
+# https://github.com/plaintextpackets/netprobe_lite/
+FROM python:3.11-slim-bookworm
 
 COPY requirements.txt /netprobe_lite/requirements.txt
 
 # Install python/pip
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update -y \ 
-&& apt-get install -y python3 \ 
-&& apt-get install -y python3-pip \ 
-&& apt-get install -y iputils-ping \ 
-&& pip install -r /netprobe_lite/requirements.txt --break-system-packages
+ENV PIP_DISABLE_PIP_VERSION_CHECK=on
+RUN apt-get update && apt-get install -y iputils-ping && apt-get clean \
+    && pip install -r /netprobe_lite/requirements.txt --break-system-packages
 
 WORKDIR /netprobe_lite
 


### PR DESCRIPTION
this change brings the size of the image from 561MB to 173MB

* add comment header
* use slim tag from python official image
* use apt-get clean
* disable pip version check