### PR TITLE
added feature to measure and display internet speeds

### DIFF
--- a/.env
+++ b/.env
@@ -39,6 +39,12 @@ threshold_latency = "100" # 100ms latency threshold as max
 threshold_jitter = "30" # 30ms jitter threshold as max
 threshold_dns_latency = "100" # 100ms dns latency threshold as max
 
+# Speetest configuration (be very careful when running on a metered connection!)
+# - This configuration is for setting up a "speed test" or rather a test of your internet bandwidth.
+# - In order to test your upload and download bandwidth we use speedtest.net as source. So your client will connect there and upload and download some data.
+# - That also means that a random server is selected for the test (usually the nearest one)
+SPEEDTEST_ENABLED="False" # set this to "True" to enable bandwidth test at all
+SPEEDTEST_INTERVAL_MULTIPLIER="60" # multiplier for the test to be executed because you probably don't want to constantly test your download speed (will be a multiple of "PROBE_INTERVAL") so defaults to 30 minutes
 
 
 # SYSTEM VARIABLES - DO NOT TOUCH

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -18,6 +18,8 @@ class Config_Netprobe():
     device_id = os.getenv('DEVICE_ID')
     site_id = os.getenv('SITE_ID')
     dns_test_site = os.getenv('DNS_TEST_SITE')
+    speedtest_enabled = os.getenv("SPEEDTEST_ENABLED", 'False').lower() in ('true', '1', 't')
+    speedtest_interval_multiplier = int(os.getenv('SPEEDTEST_INTERVAL_MULTIPLIER'))
 
     DNS_NAMESERVER_1 = os.getenv('DNS_NAMESERVER_1')
     DNS_NAMESERVER_1_IP = os.getenv('DNS_NAMESERVER_1_IP')

--- a/config/grafana/dashboards/netprobe.json
+++ b/config/grafana/dashboards/netprobe.json
@@ -1658,6 +1658,254 @@
       ],
       "transparent": true,
       "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 120,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 45
+      },
+      "id": 44,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "Speed_Stats",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{server}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Internet Bandwidth (from speedtest.net)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 13,
+        "x": 6,
+        "y": 45
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "Speed_Stats",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{server}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "alexanderzobnin-zabbix-datasource",
+        "uid": "zeKjzJc7z"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 5,
+        "x": 19,
+        "y": 45
+      },
+      "id": 46,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "## Internet Bandwidth\nIf you don't see any data you need to explicitly enable the test in the .env file configuration.\n\nBandwidth is the maximum amount of data that can travel across your internet connection at a given time. It's measured in megabits per second (Mbps), similar to how water flow is measured. Less bandwidth than what you paid for can be caused by:\n\n- Other clients down-/uploading data\n- Faulty internal hardware (including cabling or modem)\n- Faulty ISP hardware\n- ISP capacity problems",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "application": {
+            "filter": ""
+          },
+          "datasource": {
+            "type": "alexanderzobnin-zabbix-datasource",
+            "uid": "zeKjzJc7z"
+          },
+          "functions": [],
+          "group": {
+            "filter": ""
+          },
+          "host": {
+            "filter": ""
+          },
+          "item": {
+            "filter": ""
+          },
+          "itemTag": {
+            "filter": ""
+          },
+          "options": {
+            "disableDataAlignment": false,
+            "showDisabledItems": false,
+            "skipEmptyValues": false,
+            "useZabbixValueMapping": false
+          },
+          "proxy": {
+            "filter": ""
+          },
+          "queryType": "0",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "table": {
+            "skipEmptyValues": false
+          },
+          "tags": {
+            "filter": ""
+          },
+          "trigger": {
+            "filter": ""
+          },
+          "triggers": {
+            "acknowledged": 2,
+            "count": true,
+            "minSeverity": 3
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "text"
     }
   ],
   "refresh": "",

--- a/netprobe.py
+++ b/netprobe.py
@@ -19,8 +19,10 @@ if __name__ == '__main__':
     site_id = Config_Netprobe.site_id
     dns_test_site = Config_Netprobe.dns_test_site
     nameservers_external = Config_Netprobe.nameservers
+    speedtest_enabled = Config_Netprobe.speedtest_enabled
+    speedtest_interval_multiplier = Config_Netprobe.speedtest_interval_multiplier
 
-    collector = NetworkCollector(sites,probe_count,device_id,site_id,dns_test_site,nameservers_external)
+    collector = NetworkCollector(sites,probe_count,device_id,site_id,dns_test_site,nameservers_external,speedtest_enabled,speedtest_interval_multiplier)
 
     # Logging Config
 

--- a/presentation.py
+++ b/presentation.py
@@ -75,6 +75,14 @@ class CustomCollector(object):
     
         yield h
 
+        s = GaugeMetricFamily("Speed_Stats", 'Speedtest performance statistics from speedtest.net', labels=['site_id','server'])
+
+        for key in stats['speed_stats'].keys():
+            if stats['speed_stats'][key]:
+                s.add_metric([stats['site_id'],key],stats['speed_stats'][key])
+    
+        yield s
+
         # Calculate overall health score
 
         weight_loss = Config_Presentation.weight_loss # Loss is 60% of score

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.31.0
 redis==5.0.1
 python-dotenv==1.0.0
 dnspython==2.4.2
+speedtest-cli==2.1.3


### PR DESCRIPTION
Found issue #3 and also wanted to have this.
So added the feature to measure and display internet speeds.

For this speedtest.net is used with the help of [speedtest-cli](https://github.com/sivel/speedtest-cli)
As mentioned in the issue I also think this should be an optional feature for non-metered connections so it's deactivated by default.
Unfortunately I did not find a good way to hide the lane in the dashboard with the bandwith when the feature is disabled.

- added 2 config options to .env file (enabling speed testing and setting the interval)
- added new method to test the speed in the NetworkCollector
- added sending of new data to prometheus
- extended the dashboard with the speedtest metrics and a description

Any other suggestions are welcome :)