### PR TITLE
custom DNS port feature commit

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ DNS_NAMESERVER_3="CloudFlare_DNS"
 DNS_NAMESERVER_3_IP="1.1.1.1"
 DNS_NAMESERVER_4="My_DNS_Server" # Do not change this line at all!
 DNS_NAMESERVER_4_IP="8.8.8.8" # Replace this IP with the DNS server you use at home
+DNS_SERVER_PORT="53" # DNS server 4 port
 
 # Health Score Weights
 # - These are the relative weights used to calculate your 'Internet Quality Score', they can be modified but must add up to 1.0

--- a/README.md
+++ b/README.md
@@ -106,7 +106,14 @@ To do so, modify this line in .env:
 DNS_NAMESERVER_4_IP="8.8.8.8" # Replace this IP with the DNS server you use at home
 ```
 
-Change 8.8.8.8 to the IP of the DNS server you use, then restart the application (docker compose down / docker compose up)
+Change 8.8.8.8 to the IP of the DNS server you use, then restart the application (docker compose down / docker compose up --detach)
+
+To modify the port on which your DNS server responds, modify this line in .env:
+```
+DNS_NAMESERVER_4_IP="53"
+```
+
+Change 53 to your desired port, then restart the application (docker compose down; docker compose up --detach)
 
 ### Use external Grafana
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -26,7 +26,8 @@ class Config_Netprobe():
     DNS_NAMESERVER_3 = os.getenv('DNS_NAMESERVER_3')
     DNS_NAMESERVER_3_IP = os.getenv('DNS_NAMESERVER_3_IP')
     DNS_NAMESERVER_4 = os.getenv('DNS_NAMESERVER_4')
-    DNS_NAMESERVER_4_IP = os.getenv('DNS_NAMESERVER_4_IP')    
+    DNS_NAMESERVER_4_IP = os.getenv('DNS_NAMESERVER_4_IP')
+    DNS_SERVER_PORT = os.getenv('DNS_SERVER_PORT')
 
     nameservers = [
         (DNS_NAMESERVER_1,DNS_NAMESERVER_1_IP),

--- a/helpers/network_helper.py
+++ b/helpers/network_helper.py
@@ -8,7 +8,7 @@ import speedtest
 
 class NetworkCollector(object): # Main network collection class
 
-    def __init__(self,sites,count,dns_test_site,nameservers_external):
+    def __init__(self,sites,count,dns_test_site,nameservers_external,dns_port):
         self.sites = sites # List of sites to ping
         self.count = str(count) # Number of pings
         self.stats = [] # List of stat dicts
@@ -16,7 +16,7 @@ class NetworkCollector(object): # Main network collection class
         self.dns_test_site = dns_test_site # Site used to test DNS response times
         self.nameservers = []
         self.nameservers = nameservers_external
-
+        self.dns_port = dns_port
 
     def pingtest(self,count,site):
 
@@ -49,6 +49,8 @@ class NetworkCollector(object): # Main network collection class
         server = [] # Resolver needs a list
         server.append(nameserver[1])
 
+        # custom port mapping
+        my_resolver.nameserver_ports = {self.nameservers[3] : self.dns_port}
 
         try:
 

--- a/netprobe.py
+++ b/netprobe.py
@@ -17,8 +17,9 @@ if __name__ == '__main__':
     sites = Config_Netprobe.sites
     dns_test_site = Config_Netprobe.dns_test_site
     nameservers_external = Config_Netprobe.nameservers
+    dns_port = Config_Netprobe.DNS_SERVER_PORT
 
-    collector = NetworkCollector(sites,probe_count,dns_test_site,nameservers_external)
+    collector = NetworkCollector(sites,probe_count,dns_test_site,nameservers_external,dns_port)
 
     # Logging Config
 


### PR DESCRIPTION
Added ability to test custom DNS server on a port other than `53` by specifying `DNS_SERVER_PORT` variable in `.env`.

Also updated `README.md` and added comments where appropriate.

Tested before uploading.

(my first pull request, please take it easy on me :monkey: )