### PR TITLE
Fix: Division by 0 issue in presentation

### DIFF
--- a/presentation.py
+++ b/presentation.py
@@ -44,25 +44,41 @@ class CustomCollector(object):
         total_loss = 0
         total_jitter = 0
 
-        for item in stats_netprobe['stats']: # Expose each individual latency / loss metric for each site tested
+        # Check if there are any stats before proceeding
+        if len(stats_netprobe['stats']) > 0:
 
-            g.add_metric(['latency',item['site']],item['latency'])
-            g.add_metric(['loss',item['site']],item['loss'])
-            g.add_metric(['jitter',item['site']],item['jitter'])            
+            for item in stats_netprobe['stats']:
+                # Safely get latency, loss, jitter, and site values with defaults if missing
+                latency = float(item.get('latency', 0))
+                loss = float(item.get('loss', 0))
+                jitter = float(item.get('jitter', 0))
+                site = item.get('site', 'unknown')
 
-        for item in stats_netprobe['stats']: # Aggregate all latency / loss metrics into one
+                # Expose each individual latency/loss/jitter metric for each site tested
+                g.add_metric(['latency', site], latency)
+                g.add_metric(['loss', site], loss)
+                g.add_metric(['jitter', site], jitter)
 
-            total_latency += float(item['latency'])
-            total_loss += float(item['loss'])
-            total_jitter += float(item['jitter'])
+                # Aggregate totals
+                total_latency += latency
+                total_loss += loss
+                total_jitter += jitter
 
-        average_latency = total_latency / len(stats_netprobe['stats'])
-        average_loss = total_loss / len(stats_netprobe['stats'])
-        average_jitter = total_jitter / len(stats_netprobe['stats'])
+            # Calculate averages
+            average_latency = total_latency / len(stats_netprobe['stats'])
+            average_loss = total_loss / len(stats_netprobe['stats'])
+            average_jitter = total_jitter / len(stats_netprobe['stats'])
 
-        g.add_metric(['latency','all'],average_latency)
-        g.add_metric(['loss','all'],average_loss)
-        g.add_metric(['jitter','all'],average_jitter)        
+            # Add aggregated metrics for all sites
+            g.add_metric(['latency', 'all'], average_latency)
+            g.add_metric(['loss', 'all'], average_loss)
+            g.add_metric(['jitter', 'all'], average_jitter)
+
+        else:
+            # If no stats are available, report zeros for the aggregated metrics
+            g.add_metric(['latency', 'all'], 0)
+            g.add_metric(['loss', 'all'], 0)
+            g.add_metric(['jitter', 'all'], 0)     
 
         yield g
 


### PR DESCRIPTION
Suggested consideration for the submitted code snippet to avoid `Division by 0 issue in presentation` error message.

**Division by zero error:**
* When calculating the averages (`average_latency`, `average_loss`, and `average_jitter`), you're dividing by `len(stats_netprobe['stats'])`. If `stats_netprobe['stats']` is empty, this will raise a **ZeroDivisionError**.

**Type consistency:**
* You are converting `item['latency']`, `item['loss']`, and `item['jitter']` to **float** before adding them to the totals. Ensure that these values are always present in item and are numeric (either a **float** or a **string** that can be converted to a float). If not, this might raise a **ValueError**.

**Redundant looping:**
* You are iterating over `stats_netprobe['stats']` twice. You can combine the loops to calculate the totals and add the individual metrics in the same iteration, improving efficiency.

**Handling missing keys:**
* If any of the keys (`'latency'`, `'loss'`, `'jitter'`, or `'site'`) are missing from item, your code will raise a **KeyError**. You can either check the presence of the keys or use `.get()` with default values.


